### PR TITLE
Fix: force iOS 14 deployment target for RealmSwift

### DIFF
--- a/DojahWidget.podspec
+++ b/DojahWidget.podspec
@@ -9,6 +9,9 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '14.0'
   s.swift_version = '5.0'
+  s.pod_target_xcconfig = {
+  'IPHONEOS_DEPLOYMENT_TARGET' => '14.0'
+  }
   s.source_files = 'Sources/**/*.{swift,h}'
    s.resource_bundles = {
     'DojahWidgetResources' => [


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set iOS 14 deployment target for `RealmSwift` in `DojahWidget.podspec`.
> 
>   - **Configuration**:
>     - Set `IPHONEOS_DEPLOYMENT_TARGET` to `14.0` in `DojahWidget.podspec` to force iOS 14 deployment target for `RealmSwift`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dojah-inc%2Fsdk-swift&utm_source=github&utm_medium=referral)<sup> for 24f5bdc06b174a342873a8ea2fb737dfe0b3a8bc. You can [customize](https://app.ellipsis.dev/dojah-inc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->