### PR TITLE
Relax GoogleMLKit/FaceDetection pin to ~> 9.0.0

### DIFF
--- a/DojahWidget.podspec
+++ b/DojahWidget.podspec
@@ -54,7 +54,7 @@ Pod::Spec.new do |s|
   s.dependency 'IQKeyboardManagerSwift', '~> 7.1.1'
   s.dependency 'Kingfisher', '~> 7.12.0'
   s.dependency 'GooglePlaces', '~> 8.5.0'
-  s.dependency 'GoogleMLKit/FaceDetection', '8.0.0'
+  s.dependency 'GoogleMLKit/FaceDetection', '~> 9.0.0'
   s.dependency 'Clarity'
   # s.dependency 'lottie-ios'
 


### PR DESCRIPTION
Exact pin to 8.0.0 conflicted with google_mlkit_face_detection's GoogleMLKit/FaceDetection ~> 9.0.0 requirement, making pod install unresolvable for consumers on newer ML Kit.